### PR TITLE
Colab support with patched pyflamegpu wheel

### DIFF
--- a/FLAMEGPU-Tutorial.ipynb
+++ b/FLAMEGPU-Tutorial.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "### Before Beginning\n",
     "\n",
-    "If using Google Colab, please ensure you have this notebook enabled with GPU before running (Runtime->Change runtime type). If you are not using Google Colab you can ignore this instruction.\n",
+    "If using Google Colab, please ensure you have this notebook enabled with GPU before running (Runtime->Change runtime type). There are additional steps required for using this tutorial on colab below.\n",
     "\n",
     "### Running your first code cell\n",
     "\n",
@@ -48,6 +48,99 @@
    "outputs": [],
    "source": [
     "print(\"Hello!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5494cbf-3287-4940-8b48-45e912db903f",
+   "metadata": {},
+   "source": [
+    "## Using the Tutorial Within Google Colab"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42c17c4b-eae2-4ede-bd62-bfc87b138374",
+   "metadata": {},
+   "source": [
+    "If initiating a colab notebook from GitHub the Python notebook will be loaded without any of the other files present within the Readme. The following cell will pull the files from GitHub so that they are local to the notebook. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee628b08-de3e-47a1-bbb1-f1fec4174a26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "if IN_COLAB:\n",
+    "    !git init .\n",
+    "    !git remote add origin https://github.com/FLAMEGPU/FLAMEGPU2_python_sugarscape_tutorial.git\n",
+    "    !git pull origin main\n",
+    "    !git checkout main"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecbd063c-d343-47fc-9d05-0734d5730df8",
+   "metadata": {},
+   "source": [
+    "Due to a possible [bug/limitation](https://github.com/ipython/ipykernel/issues/882) in ipykernel compilation errors from FLAME GPU are not printed to the notebook and are hence inaccessible. An experimental release of FLAME GPU addresses this problem by printing any compilation errors in the exception string. You can install the CUDA and Python version specific pyflamegpu wheel using the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d054491a-62c2-45a7-b078-5832ca680adb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    !wget https://staffwww.dcs.shef.ac.uk/people/R.Chisholm/pyflamegpu-2.0.0rc3+cuda120-cp311-cp311-linux_x86_64.whl\n",
+    "    !pip install pyflamegpu-2.0.0rc3+cuda120-cp311-cp311-linux_x86_64.whl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fda20e79-4f47-4b5e-b01c-e43fbe619685",
+   "metadata": {},
+   "source": [
+    "Colab also has a known [bug](https://github.com/googlecolab/colabtools/issues/5155) with `ipympl` which is used for interactive plotting of the results. A work-around is to restart the kernel which you can do using the cell below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45ec57d5-a50d-4f76-9d42-f165de152d43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    !pip install ipympl\n",
+    "    get_ipython().kernel.do_shutdown(restart=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f579555-20f7-4716-be76-f7681b931753",
+   "metadata": {},
+   "source": [
+    "Once the kernal has restarted the following command will ensure that custom widgets are enabled (a requirement of `ipympl` within Colab). *Note that the `IN_COLAB` variable will be lost due to the restart.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f00cc3f-9de3-498d-8d0a-75ca3926325f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "if 'google.colab' in sys.modules:\n",
+    "    from google.colab import output\n",
+    "    output.enable_custom_widget_manager()"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you wish to follow this tutorial at your own pace, you can run this tutorial 
 
 ### Google Colab
 
-Google colab is currently unsupported as it is unable to display compilation errors from runtime compile agent functions. See [https://github.com/FLAMEGPU/FLAMEGPU2-tutorial-python/issues/10](https://github.com/FLAMEGPU/FLAMEGPU2-tutorial-python/issues/10)
+Google colab has patched support using an externally hosted experimenal pyflamegpu wheel built from [#5d777e0](https://github.com/FLAMEGPU/FLAMEGPU2/commit/5d777e0a28c32d0b37da309d18ec9e3afdec8150). Some additional steps are required for Colab which are described in the workbook.
 
 ### Running this Tutorial Locally
 


### PR DESCRIPTION
Adds Colab support by doing the following

- [x] Pulling supporting files from the main repo (required)
- [x] Installing experimental FLAME GPU wheel to address [known ipykernel bug](https://github.com/ipython/ipykernel/issues/882) (a new official release will avoid dependence on this bug - required before merging this PR)
- [x] Performing a kernel reset due to [known Colab bug](https://github.com/googlecolab/colabtools/issues/5155) (may be required in merge)
- [x] Executing some custom Colab code required by `ipympl` when used in Colab notebook (required)